### PR TITLE
Fix analog pad resetting during multitouch 

### DIFF
--- a/analog/analog.gd
+++ b/analog/analog.gd
@@ -62,7 +62,7 @@ func extractPointerIdx(event):
 	var mouseMove = event is InputEventMouseMotion
 	
 	if touch or drag:
-		return 1
+		return event.index
 	elif mouseButton or mouseMove:
 		return 0
 	else:


### PR DESCRIPTION
Fixes when using multiple buttons, where the pad resets when you touch another part of the screen with a different finger.

Fixes #1 (thank you @furroy for the tip!)